### PR TITLE
MAINT: bump version 0.2.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "pyansys-tools-versioning"
-version = "0.1.dev0"
+version = "0.2.dev0"
 dynamic = ["description"]
 readme = "README.rst"
 requires-python = ">=3.7"


### PR DESCRIPTION
I just realized that the package should be in version 0.2.dev0 before, as 0.1.0 is already out there.